### PR TITLE
bi-directional RTT Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,12 @@
+
+Bi-directional RTT Client (instead of just viewer) based on @bojanpotocnik's segger-rtt-viewer. Can be also used to provide input over RTT - e.g. with [Nordic Command Line Interface (CLI) RTT transfer](https://infocenter.nordicsemi.com/index.jsp?topic=%2Fcom.nordic.infocenter.sdk5.v15.0.0%2Fgroup__nrf__cli__rtt__config.html).
+
+--
+
 Contributions and pull requests are welcome!
 Due to lack of free time, the development of this project is not as active as I originally intended/wished.
 
-# Python J-Link RTT Viewer
+# Python J-Link RTT Client
 
 > [SEGGER's Real Time Transfer (RTT)](https://www.segger.com/products/debug-probes/j-link/technology/about-real-time-transfer/) is the new technology for interactive user I/O in embedded applications. It combines the advantages of SWO and semihosting at very high performance.
 
@@ -9,6 +14,8 @@ SEGGER already provides [J-Link RTT Viewer](https://www.segger.com/products/debu
 Therefore if one wish to look back at some output line, the first problem is that this line may already be out of the 100-lines scrollback limit, and even it is not, every new received message will make the terminal jump to the end.
 
 This script outputs the data to the standard console output, which can have any scrollback set and can be (un)paused with right-clicking.
+
+In addition, write functionality can be used to interact with the backend when supported by the platform.
 
 **Note**: J-Link driver/server **must be running** for this script to work. This can be done by:
  - using _J-Link Commander_ (preferred, more lightweight) with command `JLink -Device <DEVICE> -If <IF> -AutoConnect 1 -Speed <kHz>` (e.g. `JLink.exe -Device NRF52840_xxAA -AutoConnect 1 -If SWD -Speed 50000`)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+Contributions and pull requests are welcome!
+Due to lack of free time, the development of this project is not as active as I originally intended/wished.
+
 # Python J-Link RTT Viewer
 
 > [SEGGER's Real Time Transfer (RTT)](https://www.segger.com/products/debug-probes/j-link/technology/about-real-time-transfer/) is the new technology for interactive user I/O in embedded applications. It combines the advantages of SWO and semihosting at very high performance.


### PR DESCRIPTION
* Opens connection only once in the constructor
  and closes in the destructor instead of
  __enter__ and __exit__. This enables connection
  sharing between reads and writes.
* Introduces write_line to sent input to the target
  over RTT to interact

Signed-off-by: Ville Ilvonen <ville.ilvonen@forciot.com>